### PR TITLE
tropo velocity: adjust file name following Falk's suggestion

### DIFF
--- a/pysar/pysarApp.py
+++ b/pysar/pysarApp.py
@@ -793,7 +793,7 @@ class TimeSeriesAnalysis:
         tropo_model = self.template['pysar.troposphericDelay.weatherModel']
         tropo_file = './INPUTS/{}.h5'.format(tropo_model)
         if os.path.isfile(tropo_file):
-            suffix = os.path.splitext(os.path.basename(tropo_file))[0].title()
+            suffix = os.path.splitext(os.path.basename(tropo_file))[0]  #.title()
             tropo_vel_file = '{}{}.h5'.format(os.path.splitext(vel_file)[0], suffix)
             scp_args= '{f} -t {t} -o {o} --update'.format(f=tropo_file,
                                                           t=self.templateFile,
@@ -856,7 +856,9 @@ class TimeSeriesAnalysis:
 
             # update mode
             try:
-                kmz_file = [i for i in [kmz_file, 'PIC/{}'.format(kmz_file)] if os.path.isfile(i)][0]
+                fbase = os.path.basename(kmz_file)
+                kmz_file = [i for i in [fbase, './GEOCODE/{}'.format(fbase), './PIC/{}'.format(fbase)] 
+                            if os.path.isfile(i)][0]
             except:
                 kmz_file = None
             if ut.run_or_skip(out_file=kmz_file, in_file=vel_file, check_readable=False) == 'run':

--- a/sh/plot_pysarApp.sh
+++ b/sh/plot_pysarApp.sh
@@ -112,7 +112,7 @@ fi
 
 
 if [ $plot_the_rest -eq 1 ]; then
-    for trop in 'Ecmwf' 'Merra' 'Narr'
+    for trop in 'ECMWF' 'MERRA' 'NARR'
     do
         file=velocity${trop}.h5;    test -f $file && $view $file --mask no >> $log_file
     done
@@ -122,7 +122,5 @@ fi
 
 ## Move picture files to PIC folder
 echo "Move *.png/pdf/kmz files into ./PIC folder."
-mv *.png PIC/
-mv *.pdf PIC/
-mv *.kmz ./GEOCODE/*.kmz PIC/
+mv *.png *.pdf *.kmz ./GEOCODE/*.kmz PIC/
 


### PR DESCRIPTION
pysarApp.py:
+ adjust the velocity file name of tropospheric delay time-series: use `velocityECMWF.h5` instead of `velocityEcmwf.h5`, to be more consistent with other file names.

+ fix bug related with the update mode of save_kmz.py calling.

adjust plot_pysarApp.sh accordingly.