### PR TITLE
save_roipac: drop all lower case keys for geodmod

### DIFF
--- a/pysar/save_roipac.py
+++ b/pysar/save_roipac.py
@@ -161,9 +161,16 @@ def clean_metadata4roipac(atr_in):
     for key, value in atr_in.items():
         atr[key] = str(value)
 
+    # drop the following keys
     key_list = ['width', 'Width', 'samples', 'length', 'lines']
     for key in key_list:
         if key in atr.keys():
+            atr.pop(key)
+
+    # drop all keys that are not all UPPER_CASE
+    key_list = list(atr.keys())
+    for key in key_list:
+        if not key.isupper():
             atr.pop(key)
 
     atr['FILE_LENGTH'] = atr['LENGTH']
@@ -178,7 +185,7 @@ def main(iargs=None):
 
     atr = clean_metadata4roipac(atr)
 
-    print('writing >>> {}'.format(out_file))
+    #print('writing >>> {}'.format(out_file))
     writefile.write(data, out_file=out_file, metadata=atr)
     return inps.outfile
 

--- a/pysar/utils/readfile.py
+++ b/pysar/utils/readfile.py
@@ -313,8 +313,8 @@ def read_binary_file(fname, datasetName=None, box=None):
         data_type = atr['DATA_TYPE'].lower()
         if data_type in dataTypeDict.keys():
             data_type = dataTypeDict[data_type]
-        num_band = int(atr['number_bands'])
-        band_interleave = atr['scheme'].upper()
+        num_band = int(atr.get('number_bands', '1'))
+        band_interleave = atr.get('scheme', 'BIL').upper()
         byte_order = 'l'
 
         # data structure - file specific based on FILE_TYPE - k

--- a/pysar/utils/writefile.py
+++ b/pysar/utils/writefile.py
@@ -115,7 +115,7 @@ def write(datasetDict, out_file, metadata=None, ref_file=None, compression=None)
             data_list.append(datasetDict[key])
 
         # Write Data File
-        print('writing {}'.format(out_file))
+        print('write {}'.format(out_file))
         if ext in ['.unw', '.cor', '.hgt']:
             write_float32(data_list[0], out_file)
             meta['DATA_TYPE'] = 'float32'


### PR DESCRIPTION
+ save_roipac: drop all attributes with key name not all upper case, to better support geodmod

+ utils/readfile: add default value for num_band and band_interleave