### PR TITLE
Included dask-jobqueue in the imports

### DIFF
--- a/docs/conda.txt
+++ b/docs/conda.txt
@@ -1,6 +1,7 @@
 basemap
 cvxopt
 dask>=1.0,<2.0
+dask-jobqueue<1.0
 ecCodes
 h5py
 lxml

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ basemap
 bokeh
 cvxopt
 dask[complete]>=1.0,<2.0
+dask-jobqueue<1.0
 ecCodes
 h5py
 lxml


### PR DESCRIPTION
dask-jobqueue is the library used to run Dask on HPC. I forgot to include this install in the last Dask Install commit: https://github.com/insarlab/PySAR/commit/3b1b5ab01b67971db07f1de51c5add093643ee2b