### PR TITLE
Added Dask config defaults & fixed #31

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -38,6 +38,15 @@ export PATH=${PATH}:${PYSAR_HOME}/pysar:${PYSAR_HOME}/sh
 
 Source the file for the first time. It will be sourced automatically next time when you login. [Here](https://github.com/yunjunz/macOS_Setup/blob/master/cshrc.md) is an example _.cshrc_ file for csh/tcsh user.
 
+To run PySAR in parallel on a High Performance Compute cluster, set up [Dask](www.dask.org) by executing the following commands:
+
+ ```
+ mkdir ~/.config
+ mkdir ~/.config/dask
+ cp $PYSAR_HOME/pysar/defaults/dask_pysar.yaml ~/.config/dask/dask_pysar.yaml
+ ```
+
+It is okay if you get a `File Exists` message when running the commands above.
 
 ### 2. Install Python dependecies
 PySAR is written in Python3 (3.5+) and it relies on several Python modules, check the [requirements.txt](../requirements.txt) file for details. We recommend using [conda](https://conda.io/miniconda.html) or [macports](https://www.macports.org/install.php) to install the python environment and the prerequisite packages, because of the convenient managenment and default [performance setting with numpy/scipy](http://markus-beuckelmann.de/blog/boosting-numpy-blas.html) and [pyresample](https://pyresample.readthedocs.io/en/latest/installation.html#using-pykdtree).

--- a/pysar/defaults/dask_pysar.yaml
+++ b/pysar/defaults/dask_pysar.yaml
@@ -1,0 +1,85 @@
+jobqueue:
+  lsf:
+    queue: general
+    project: insarlab
+    name: pysar_worker_bee
+
+    # Dask worker options
+    cores: 2                    # Total number of cores per job
+    memory: 2GB                 # This parameter is ignored by Pegasus
+    processes: 1                # Number of Python processes per job
+
+    interface: ib0              # Network interface to use like eth0 or ib0
+                                # ESSENTIAL PARAMETER for performance
+                               
+    death-timeout: 60           # Number of seconds to wait if a worker can not find a scheduler
+    local-directory: null       # Location of fast local storage like /scratch or $TMPDIR
+
+    # LSF resource manager options
+    shebang: "#!/usr/bin/env bash"
+    walltime: '00:30'
+    extra: []
+    env-extra: []
+    ncpus: null
+    mem: null
+    # The first parameter is required by Pegasus. This parameter sets the 
+    # memory per node. The second parameter writes worker output to file.
+    job-extra: ['-R "rusage[mem=6400]"',
+                "-o WORKER-%J.out"]
+    log-directory: null
+    
+######################################################## 
+  ifgram_inversion:
+    queue: general
+    project: insarlab
+    name: ifgram_inversion_worker_bee 
+
+    # Dask worker options
+    cores: 2                    # Total number of cores per job
+    memory: 2GB                 # This parameter is ignored by Pegasus
+    processes: 1                # Number of Python processes per job
+
+    interface: ib0              # Network interface to use like eth0 or ib0
+                                # ESSENTIAL PARAMETER for performance
+                               
+    death-timeout: 60           # Number of seconds to wait if a worker can not find a scheduler
+    local-directory: null       # Location of fast local storage like /scratch or $TMPDIR
+
+    # LSF resource manager options
+    shebang: "#!/usr/bin/env bash"
+    walltime: '00:30'
+    extra: []
+    env-extra: []
+    ncpus: null
+    mem: null
+    # The first parameter is required by Pegasus. This parameter sets the 
+    # memory per node. The second parameter writes worker output to file.
+    job-extra: ['-R "rusage[mem=6400]"',
+                "-o IFGRAM_WORKER_%J.out"]
+    log-directory: null
+    
+######################################################## 
+    
+  pbs:
+    name: dask-worker
+
+    # Dask worker options
+    cores: null                 # Total number of cores per job
+    memory: null                # Total amount of memory per job
+    processes: 1                # Number of Python processes per job
+
+    interface: null             # Network interface to use like eth0 or ib0
+    death-timeout: 60           # Number of seconds to wait if a worker can not find a scheduler
+    local-directory: null       # Location of fast local storage like /scratch or $TMPDIR
+
+    # PBS resource manager options
+    shebang: "#!/usr/bin/env bash"
+    queue: null
+    project: null
+    walltime: '00:30:00'
+    extra: []
+    env-extra: []
+    resource-spec: null
+    job-extra: []
+    log-directory: null
+

--- a/pysar/ifgram_inversion.py
+++ b/pysar/ifgram_inversion.py
@@ -10,6 +10,7 @@
 
 import os
 import re
+import sys
 import time
 import argparse
 import h5py
@@ -18,6 +19,12 @@ from scipy import linalg   # more effieint than numpy.linalg
 from scipy.special import gamma
 from pysar.objects import ifgramStack, timeseries
 from pysar.utils import readfile, writefile, ptime, utils as ut
+
+# Imports for parallel execution
+from dask.distributed import Client, as_completed
+# dask_jobqueue is needed for HPC.
+# PBSCluster (similar to LSFCluster) should also work out of the box
+from dask_jobqueue import LSFCluster
 
 
 # key configuration parameter name
@@ -569,12 +576,14 @@ def split_into_boxes(dataset_shape, chunk_size=100e6, print_msg=True):
     return box_list
 
 
-def subsplit_boxes_by_num_workers(box, num_workers, dimension='y'):
-    """ David: This is a bit hacky, but after creating the patches,
-    I wanted to further divide the box size into `num_subboxes` different subboxes.
-    Note that `split_into_boxes` only splits based on chunk_size (memory-based).
+def subsplit_boxes_by_num_workers(box, number_of_splits, dimension='y'):
+    """ This is a bit hacky, but after creating the patches,
+    this function further divides the box size into `number_of_splits` different subboxes.
+    Note that `split_into_boxes`  splits based on chunk_size (memory-based).
 
-    :param box: [x0, y0, x1, y1]: list[int] of size 4,
+    :param box: [x0, y0, x1, y1]: list[int] of size 4
+    :param number_of_splits: int, the number of subboxes to split a box into
+    :param dimension: str = 'y' or 'x', the dimension along which to split the boxes
     """
 
     # Flip x and y coordinates if splitting along 'x' dimension
@@ -583,15 +592,15 @@ def subsplit_boxes_by_num_workers(box, num_workers, dimension='y'):
 
     if dimension == 'y':
         y_diff = y1 - y0
-        for i in range(num_workers):
-            start = (i * y_diff) // num_workers
-            end = ((i + 1) * y_diff) // num_workers if i + 1 != num_workers else y_diff
+        for i in range(number_of_splits):
+            start = (i * y_diff) // number_of_splits
+            end = ((i + 1) * y_diff) // number_of_splits if i + 1 != number_of_splits else y_diff
             subboxes.append([x0, start, x1, end])
     elif dimension == 'x':
         x_diff = x1 - x0
-        for i in range(num_workers):
-            start = (i * x_diff) // num_workers
-            end = ((i + 1) * x_diff) // num_workers if i + 1 != num_workers else x_diff
+        for i in range(number_of_splits):
+            start = (i * x_diff) // number_of_splits
+            end = ((i + 1) * x_diff) // number_of_splits if i + 1 != number_of_splits else x_diff
             subboxes.append([start, y0, end, y1])
     else:
         raise Exception("Unknown value for dimension parameter:", dimension)
@@ -1028,97 +1037,7 @@ def ifgram_inversion(ifgram_file='ifgramStack.h5', inps=None):
         num_inv_ifg = np.zeros((length, width), np.int16)
 
         # Loop
-        if inps.parallel:
-            from dask.distributed import Client, as_completed
-            # David: dask_jobqueue is needed for HPC.
-            # PBSCluster (similar to LSFCluster) should also work out of the box
-            from dask_jobqueue import LSFCluster
-
-            # Initialize Dask Workers.
-            # TODO: Should these params be moved into a config file?
-            # We could use our own config setup or Dask's config setup
-            NUM_WORKERS = 40
-            cluster = LSFCluster(project='insarlab',
-                                 name='pysar_worker_bee2',
-                                 queue='general',
-                                 # David: The first parameter is required by Pegasus. This actually changes memory usage.
-                                 job_extra=['-R "rusage[mem=6400]"',
-                                            # David: This second line will allow you to read your worker's output
-                                            "-o WORKER-%J.out"],
-                                 # David: This allows workers to write overflow memory to file. Unsure if necessary
-                                 local_directory='/scratch/projects/insarlab/dwg11/',
-                                 # David: Somehow, cores=2 is essential. When cores=1 it was super slow and
-                                 # when cores=3 it took forever for workers to go from PENDING to RUNNING
-                                 cores=2,
-                                 walltime='00:30',
-                                 # David: This line is required by dask_jobqueue
-                                 # but ignored by Pegasus as far as I can tell
-                                 memory='2GB',
-                                 # David: This line prevents the cluster from defaulting to the system Python.
-                                 # You need to point it to your dask environment's Python
-                                 python='/nethome/dwg11/anaconda2/envs/pysar_parallel/bin/python')
-            # David:  This line submits NUM_WORKERS number of jobs to Pegasus to start a bunch of workers
-            cluster.scale(NUM_WORKERS)
-            print("JOB FILE:", cluster.job_script())
-
-            # David: This line needs to be in an `if __name__ == "__main__":` block I believe. It should not
-            # be floating around or in code that workers might execute (note that if it is in no function,
-            # workers will execute it when loading the module)
-            #
-            client = Client(cluster)
-
-            all_boxes = []
-            for i in range(num_box):
-                # David: All "patches" are processed at once
-                # David: You can change the factor of `num_subboxes` to have smaller jobs per worker.
-                # This could be helpful with large jobs
-                all_boxes += subsplit_boxes_by_num_workers(box_list[i], num_workers=1 * NUM_WORKERS, dimension='x')
-
-            futures = []
-            start_time_subboxes = time.time()
-            for i, subbox in enumerate(all_boxes):
-                print(i, subbox)
-
-                data = (ifgram_file,
-                        subbox,
-                        ref_phase,
-                        inps.unwDatasetName,
-                        inps.weightFunc,
-                        inps.minNormVelocity,
-                        inps.maskDataset,
-                        inps.maskThreshold,
-                        inps.minRedundancy,
-                        inps.waterMaskFile,
-                        inps.skip_zero_phase)
-
-
-                # David: I haven't played with fussing with `retries`, however sometimes a future fails
-                # on a worker for an unknown reason. retrying will save the whole process from failing.
-                # David: TODO:  I don't know what to do if a future fails > 3 times. I don't think an error is
-                # thrown in that case, therefore I don't know how to recognize when this happens.
-                future = client.submit(parallel_ifgram_inversion_patch, data, retries=3)
-                futures.append(future)
-
-            # David: Some workers are slower than others. When #(futures to complete) < #workers, we should
-            # investigate whether `Client.replicate(future)` will speed up work on the final futures.
-            # It's a slight speedup, but depending how computationally complex each future is, this could be a
-            # decent speedup
-            i_future = 0
-            for future, result in as_completed(futures, with_results=True):
-                i_future += 1
-                print("FUTURE #" + str(i_future), "complete in", time.time() - start_time_subboxes,
-                      "seconds. Box:", subbox, "Time:", time.time())
-                tsi, temp_cohi, ts_stdi, ifg_numi, subbox = result
-
-                ts[:, subbox[1]:subbox[3], subbox[0]:subbox[2]] = tsi
-                ts_std[:, subbox[1]:subbox[3], subbox[0]:subbox[2]] = ts_stdi
-                temp_coh[subbox[1]:subbox[3], subbox[0]:subbox[2]] = temp_cohi
-                num_inv_ifg[subbox[1]:subbox[3], subbox[0]:subbox[2]] = ifg_numi
-
-            # Shut down Dask workers gracefully
-            client.close()
-            cluster.close()
-        else:
+        if not inps.parallel:
             for i in range(num_box):
                 box = box_list[i]
                 if num_box > 1:
@@ -1143,6 +1062,75 @@ def ifgram_inversion(ifgram_file='ifgramStack.h5', inps=None):
                 temp_coh[box[1]:box[3], box[0]:box[2]] = temp_cohi
                 num_inv_ifg[box[1]:box[3], box[0]:box[2]] = ifg_numi
 
+        # Parallel loop
+        else:
+            NUM_WORKERS = 40
+            python_executable_location = sys.executable
+
+            # Look at the dask.yaml file for Changing the Dask configuration defaults
+            cluster = LSFCluster(configuration='ifgram_inversion',
+                                 python=python_executable_location)
+
+            # This line submits NUM_WORKERS number of jobs to Pegasus to start a bunch of workers
+            cluster.scale(NUM_WORKERS)
+            print("JOB FILE:", cluster.job_script())
+
+            # This line needs to be in a function or in a `if __name__ == "__main__":` block. If it is in no function
+            # or "main" block, each worker will try to create its own client (which is bad) when loading the module
+            client = Client(cluster)
+
+            all_boxes = []
+            for box in box_list:
+                # `box_list` is split into smaller boxes and then each box is processed in parallel
+                # With larger jobs, increasing the `number_of_splits` factor may improve runtime
+                all_boxes += subsplit_boxes_by_num_workers(box, number_of_splits=1 * NUM_WORKERS, dimension='x')
+
+            futures = []
+            start_time_subboxes = time.time()
+            for i, subbox in enumerate(all_boxes):
+                print(i, subbox)
+
+                data = (ifgram_file,
+                        subbox,
+                        ref_phase,
+                        inps.unwDatasetName,
+                        inps.weightFunc,
+                        inps.minNormVelocity,
+                        inps.maskDataset,
+                        inps.maskThreshold,
+                        inps.minRedundancy,
+                        inps.waterMaskFile,
+                        inps.skip_zero_phase)
+
+                # David: I haven't played with fussing with `retries`, however sometimes a future fails
+                # on a worker for an unknown reason. retrying will save the whole process from failing.
+                # TODO:  I don't know what to do if a future fails > 3 times. I don't think an error is
+                # thrown in that case, therefore I don't know how to recognize when this happens.
+                future = client.submit(parallel_ifgram_inversion_patch, data, retries=3)
+                futures.append(future)
+
+            # Some workers are slower than others. When #(futures to complete) < #workers, we should
+            # investigate whether `Client.replicate(future)` will speed up work on the final futures.
+            # It's a slight speedup, but depending how computationally complex each future is, this could be a
+            # decent speedup
+            i_future = 0
+            for future, result in as_completed(futures, with_results=True):
+                i_future += 1
+                print("FUTURE #" + str(i_future), "complete in", time.time() - start_time_subboxes,
+                      "seconds. Box:", subbox, "Time:", time.time())
+                tsi, temp_cohi, ts_stdi, ifg_numi, subbox = result
+
+                ts[:, subbox[1]:subbox[3], subbox[0]:subbox[2]] = tsi
+                ts_std[:, subbox[1]:subbox[3], subbox[0]:subbox[2]] = ts_stdi
+                temp_coh[subbox[1]:subbox[3], subbox[0]:subbox[2]] = temp_cohi
+                num_inv_ifg[subbox[1]:subbox[3], subbox[0]:subbox[2]] = ifg_numi
+
+            # Shut down Dask workers gracefully
+            client.close()
+            cluster.close()
+
+
+
         # reference pixel
         ref_y = int(stack_obj.metadata['REF_Y'])
         ref_x = int(stack_obj.metadata['REF_X'])
@@ -1162,7 +1150,7 @@ def ifgram_inversion(ifgram_file='ifgramStack.h5', inps=None):
 
 def parallel_ifgram_inversion_patch(data):
     """
-    David: This is the starting point for futures. Futures start executing code here.
+    This is the starting point for Dask futures. Futures start executing code here.
     :param data:
     :return: The box
     """
@@ -1173,8 +1161,7 @@ def parallel_ifgram_inversion_patch(data):
 
     print("BOX DIMS:", box)
 
-    # David: This is the main call. This code was copied from the old
-    # `ifgram_inversion` function
+    # This line is where all of the processing happens.
     (tsi, temp_cohi, ts_stdi, ifg_numi) = ifgram_inversion_patch(ifgram_file,
                                            box= box,
                                            ref_phase= ref_phase,

--- a/pysar/ifgram_inversion.py
+++ b/pysar/ifgram_inversion.py
@@ -46,7 +46,7 @@ EXAMPLE = """example:
   ifgram_inversion.py  INPUTS/ifgramStack.h5 -w fim
   ifgram_inversion.py  INPUTS/ifgramStack.h5 -w coh
   ifgram_inversion.py  INPUTS/ifgramStack.h5 -w var --parallel
-  ifgram_inversion.py  INPUTS/ifgramStack.h5 -w var --parallel --parallel_number_of_workers 25
+  ifgram_inversion.py  INPUTS/ifgramStack.h5 -w var --parallel --num_workers 25
 """
 
 TEMPLATE = """
@@ -130,8 +130,8 @@ def create_parser():
                         'default: 0.2 G; adjust it according to your computer memory.')
     parser.add_argument('--parallel', dest='parallel', action='store_true',
                         help='Enable parallel processing for the pixelwise weighted inversion.')
-    parser.add_argument('--parallel_number_of_workers', dest='parallel_number_of_workers', type=int,
-                        default=0, help='Specify the number of workers the Dask cluster should use')
+    parser.add_argument('--parallel-num','--workers-num', dest='num_workers', type=int,
+                        default=40, help='Specify the number of workers the Dask cluster should use. Default: 40')
     parser.add_argument('--skip-reference', dest='skip_ref', action='store_true',
                         help='Skip checking reference pixel value, for simulation testing.')
     parser.add_argument('-o', '--output', dest='outfile', nargs=2,
@@ -1097,10 +1097,7 @@ def ifgram_inversion(ifgram_file='ifgramStack.h5', inps=None):
             # This line submits NUM_WORKERS jobs to Pegasus to start a bunch of workers
             # In tests on Pegasus `general` queue in Jan 2019, no more than 40 workers could RUN
             # at once (other user's jobs gained higher priority in the general at that point)
-            if inps.parallel_number_of_workers == 0:
-                NUM_WORKERS = 40
-            else:
-                NUM_WORKERS = inps.parallel_number_of_workers
+            NUM_WORKERS = inps.num_workers
             cluster.scale(NUM_WORKERS)
             print("JOB FILE:", cluster.job_script())
 

--- a/pysar/ifgram_inversion.py
+++ b/pysar/ifgram_inversion.py
@@ -46,7 +46,7 @@ EXAMPLE = """example:
   ifgram_inversion.py  INPUTS/ifgramStack.h5 -w fim
   ifgram_inversion.py  INPUTS/ifgramStack.h5 -w coh
   ifgram_inversion.py  INPUTS/ifgramStack.h5 -w var --parallel
-  ifgram_inversion.py  INPUTS/ifgramStack.h5 -w var --parallel --workers-num 25
+  ifgram_inversion.py  INPUTS/ifgramStack.h5 -w var --parallel --parallel-workers-num 25
 """
 
 TEMPLATE = """
@@ -128,10 +128,13 @@ def create_parser():
     parser.add_argument('--chunk-size', dest='chunk_size', type=float, default=100e6,
                         help='max number of data (= ifgram_num * num_row * num_col) to read per loop\n' +
                         'default: 0.2 G; adjust it according to your computer memory.')
-    parser.add_argument('--parallel', dest='parallel', action='store_true',
-                        help='Enable parallel processing for the pixelwise weighted inversion.')
-    parser.add_argument('--parallel-num','--workers-num', dest='num_workers', type=int,
-                        default=40, help='Specify the number of workers the Dask cluster should use. Default: 40')
+
+    par = parser.add_argument_group('parallel', 'parallel processing configuration')
+    par.add_argument('--parallel', dest='parallel', action='store_true',
+                     help='Enable parallel processing for the pixelwise weighted inversion.')
+    par.add_argument('--parallel-workers-num','--par-workers-num','--parallel-num', dest='num_workers', type=int,
+                     default=40, help='Specify the number of workers the Dask cluster should use. Default: 40')
+
     parser.add_argument('--skip-reference', dest='skip_ref', action='store_true',
                         help='Skip checking reference pixel value, for simulation testing.')
     parser.add_argument('-o', '--output', dest='outfile', nargs=2,

--- a/pysar/ifgram_inversion.py
+++ b/pysar/ifgram_inversion.py
@@ -46,7 +46,7 @@ EXAMPLE = """example:
   ifgram_inversion.py  INPUTS/ifgramStack.h5 -w fim
   ifgram_inversion.py  INPUTS/ifgramStack.h5 -w coh
   ifgram_inversion.py  INPUTS/ifgramStack.h5 -w var --parallel
-  ifgram_inversion.py  INPUTS/ifgramStack.h5 -w var --parallel --num_workers 25
+  ifgram_inversion.py  INPUTS/ifgramStack.h5 -w var --parallel --workers-num 25
 """
 
 TEMPLATE = """


### PR DESCRIPTION
This commit is larger than I'd like it to be but it includes the following changes:
1. Creation and use of Dask configuration using [Dask's configuration setup](http://jobqueue.dask.org/en/latest/configuration-setup.html)
2. A fix of #31, where Dask workers cannot find the `gamma` function and therefore throw an exception
3. Moving the imports for Dask to the top of `ifgram_inversion.p`
4. Updates to the documentation
5. Having the code where `inps.parallel` is False be before the parallel case. I think this makes the code more readable

@yunjunz could you please test to make sure the `inps.parallel = False`  case works?

Also, once this Pull Request is merged, you should be able to run Dask on Pegasus!!!