### PR TITLE
save_roipac: support HDF_EOS5 file

### DIFF
--- a/pysar/objects/pysarobj.py
+++ b/pysar/objects/pysarobj.py
@@ -1128,6 +1128,12 @@ class HDFEOS:
         self.refIndex = dateList.index(self.metadata['REF_DATE'])
         return self.metadata
 
+    def get_date_list(self):
+        with h5py.File(self.file, 'r') as f:
+            g = f['HDFEOS/GRIDS/timeseries/observation']
+            self.dateList = [i.decode('utf8') for i in g['date'][:]]
+        return self.dateList
+
     def read(self, datasetName=None, box=None, print_msg=True):
         """Read dataset from HDF-EOS5 file
         Parameters: self : HDFEOS object

--- a/pysar/save_roipac.py
+++ b/pysar/save_roipac.py
@@ -1,28 +1,47 @@
 #!/usr/bin/env python3
 ############################################################
 # Program is part of PySAR                                 #
-# Copyright(c) 2013-2018, Heresh Fattahi, Zhang Yunjun     #
-# Author:  Heresh Fattahi, Zhang Yunjun                    #
+# Copyright(c) 2013-2019, Zhang Yunjun, Heresh Fattahi     #
+# Author:  Zhang Yunjun, Heresh Fattahi                    #
 ############################################################
 
 
 import os
 import argparse
 import numpy as np
-from pysar.objects import timeseries
+from pysar.objects import timeseries, HDFEOS
 from pysar.utils import readfile, writefile, ptime
+from pysar import view
 
 
 ##############################################################################
 EXAMPLE = """example:
+  #----- unwrapped phase
+  #for velocity: output an interferogram with one year temporal baseline in input rate
   save_roipac.py  velocity.h5
-  save_roipac.py  timeseries.h5    20050601
-  save_roipac.py  timeseries.h5    20050601    --ref-date 20040728
+
+  #for time-series: specify (date1_)date2
+  save_roipac.py  timeseries_ERA5_ramp_demErr.h5  #use the last date
+  save_roipac.py  timeseries_ERA5_ramp_demErr.h5  20050601
+  save_roipac.py  timeseries_ERA5_ramp_demErr.h5  20040728_20050601
+
+  #for HDF-EOS5: specify displacement-date1_date2
+  save_roipac.py  S1_IW12_128_0593_0597_20141213_20180619.he5  displacement-20170904_20170916
+  save_roipac.py  S1_IW12_128_0593_0597_20141213_20180619.he5  displacement-20170916
+
+  #for ifgramStack: specify date1_date2
   save_roipac.py  INPUTS/ifgramStack.h5  unwrapPhase-20091225_20100723
   save_roipac.py  INPUTS/ifgramStack.h5  unwrapPhase-20091225_20100723  --ref-yx 640 810
-  save_roipac.py  INPUTS/ifgramStack.h5    coherence-20091225_20100723
+
+  #----- coherence
+  save_roipac.py  INPUTS/ifgramStack.h5  coherence-20091225_20100723
   save_roipac.py  temporalCoherence.h5
-  save_roipac.py  GEOCODE/geo_geometryRadar.h5  height  -o height.dem
+  save_roipac.py  S1_IW12_128_0593_0597_20141213_20180619.he5 temporalCoherence -o 20170904_20170916.cor
+
+  #----- DEM
+  save_roipac.py  geo_geometryRadar.h5  height -o srtm1.dem
+  save_roipac.py  geo_geometryRadar.h5  height -o srtm1.hgt
+  save_roipac.py  S1_IW12_128_0593_0597_20141213_20180619.he5 height -o srtm1.dem
 """
 
 
@@ -31,112 +50,186 @@ def create_parser():
                                      formatter_class=argparse.RawTextHelpFormatter,
                                      epilog=EXAMPLE)
 
-    parser.add_argument('file', help='HDF5 file to be converted.\n' +
-                        'for velocity  : the ouput will be a one year interferogram.\n' +
-                        'for timeseries: if date is not specified, the last date will be used.')
-    parser.add_argument('dset', nargs='?',
-                        help='date of timeseries, or date12 of interferograms to be converted')
-    parser.add_argument('-o', '--output', dest='outfile',
-                        help='output file name.')
-    parser.add_argument('-r', '--ref-date', dest='ref_date',
-                        help='Reference date for timeseries file')
-    parser.add_argument('--ref-yx', dest='ref_yx', type=int, nargs=2,
-                        help='custom reference pixel in y/x')
+    parser.add_argument('file', help='HDF5 file to be converted.')
+    parser.add_argument('dset', nargs='?', help='date/date12 of timeseries, or date12 of interferograms to be converted')
+    parser.add_argument('-o', '--output', dest='outfile', help='output file name.')
+    parser.add_argument('--ref-yx', dest='ref_yx', type=int, nargs=2, help='custom reference pixel in y/x')
     return parser
 
 
 def cmd_line_parse(iargs=None):
     parser = create_parser()
     inps = parser.parse_args(args=iargs)
-    if inps.ref_date:
-        inps.ref_date = ptime.yyyymmdd(inps.ref_date)
+
+    # default dset
+    if not inps.dset:
+        atr = readfile.read_attribute(inps.file)
+        k = atr['FILE_TYPE']
+        if k in ['ifgramStack', 'HDFEOS']:
+            raise Exception("NO input dataset! It's required for {} file".format(k))
+
+        #for time-series
+        if k == 'timeseries':
+            inps.dset = timeseries(inps.file).get_date_list()[-1]
+            print('NO date specified >>> continue with the last date: {}'.format(inps.dset))
     return inps
 
 
 def read_data(inps):
+    # metadata
     atr = readfile.read_attribute(inps.file)
-    k = atr['FILE_TYPE']
+    range2phase = -4 * np.pi / float(atr['WAVELENGTH'])
 
+    # change reference pixel
     if inps.ref_yx:
         atr['REF_Y'] = inps.ref_yx[0]
         atr['REF_X'] = inps.ref_yx[1]
         print('change reference point to y/x: {}'.format(inps.ref_yx))
 
-    if not inps.dset:
-        if k == 'timeseries':
-            print('No input date specified >>> continue with the last date')
-            inps.dset = timeseries(inps.file).get_date_list()[-1]
-        elif k == 'ifgramStack':
-            raise Exception("No input dataset! It's required for {} file".format(k))
-
+    # various file types
     print('read {} from file {}'.format(inps.dset, inps.file))
-    data = readfile.read(inps.file, datasetName=inps.dset, print_msg=False)[0]
-    range2phase = -4 * np.pi / float(atr['WAVELENGTH'])
+    k = atr['FILE_TYPE']
     if k == 'velocity':
-        print("converting velocity to a 1 year interferogram.")
-        data *= range2phase
+        # read/prepare data
+        data = readfile.read(inps.file)[0] * range2phase
+        print("converting velocity to an interferogram with one year temporal baseline")
         if inps.ref_yx:
             data -= data[inps.ref_yx[0], inps.ref_yx[1]]
+
+        # metadata
         atr['FILE_TYPE'] = '.unw'
         atr['UNIT'] = 'radian'
+
+        # output filename
         if not inps.outfile:
             inps.outfile = '{}{}'.format(os.path.splitext(inps.file)[0], atr['FILE_TYPE'])
 
     elif k == 'timeseries':
-        if inps.ref_date:
-            print('read {} from file {}'.format(inps.ref_date, inps.file))
-            data -= readfile.read(inps.file, datasetName=inps.ref_date)[0]
-            atr['DATE'] = inps.ref_date[2:8]
-            atr['DATE12'] = '{}-{}'.format(inps.ref_date[2:8], inps.dset[2:8])
+        # date1 and date2
+        if '_' in inps.dset:
+            date1, date2 = ptime.yyyymmdd(inps.dset.split('_'))
         else:
-            try:
-                atr['DATE'] = atr['REF_DATE']
-                atr['DATE12'] = '{}-{}'.format(atr['REF_DATE'][2:8], inps.dset[2:8])
-            except:
-                pass
+            date1 = atr['REF_DATE']
+            date2 = ptime.yyyymmdd(inps.dset)
 
+        # read/prepare data
+        data = readfile.read(inps.file, datasetName=date2)[0]
+        data -= readfile.read(inps.file, datasetName=date1)[0]
         print('converting range to phase')
         data *= range2phase
         if inps.ref_yx:
             data -= data[inps.ref_yx[0], inps.ref_yx[1]]
+
+        # metadata
+        atr['DATE'] = date1[2:8]
+        atr['DATE12'] = '{}-{}'.format(date1[2:8], date2[2:8])
         atr['FILE_TYPE'] = '.unw'
         atr['UNIT'] = 'radian'
+
+        # output filename
         if not inps.outfile:
-            inps.outfile = '{}{}'.format(atr['DATE12'], atr['FILE_TYPE'])
+            inps.outfile = '{}_{}.unw'.format(date1, date2)
             if inps.file.startswith('geo_'):
                 inps.outfile = 'geo_'+inps.outfile
 
-    elif k == 'ifgramStack':
-        dsetFamily, atr['DATE12'] = inps.dset.split('-')
-        if dsetFamily == 'unwrapPhase':
-            if 'REF_X' in atr.keys():
-                data -= data[int(atr['REF_Y']), int(atr['REF_X'])]
-                print('consider the reference pixel in y/x: ({}, {})'.format(atr['REF_Y'],
-                                                                             atr['REF_X']))
+    elif k == 'HDFEOS':
+        dname = inps.dset.split('-')[0]
+
+        # date1 and date2
+        if dname == 'displacement':
+            if '-' in inps.dset:
+                suffix = inps.dset.split('-')[1]
+                if '_' in suffix:
+                    date1, date2 = ptime.yyyymmdd(suffix.split('_'))
+                else:
+                    date1 = atr['REF_DATE']
+                    date2 = ptime.yyyymmdd(suffix)
             else:
-                print('No ref_y/x info found in attributes.')
+                raise ValueError("No '-' in input dataset! It is required for {}".format(dname))
+        else:
+            date_list = HDFEOS(inps.file).get_date_list()
+            date1 = date_list[0]
+            date2 = date_list[-1]
+        date12 = '{}_{}'.format(date1, date2)
+
+        # read / prepare data
+        slice_list = readfile.get_slice_list(inps.file)
+        if 'displacement' in inps.dset:
+            # read/prepare data
+            slice_name1 = view.check_dataset_input(slice_list, '{}-{}'.format(dname, date1))[0][0]
+            slice_name2 = view.check_dataset_input(slice_list, '{}-{}'.format(dname, date2))[0][0]
+            data = readfile.read(inps.file, datasetName=slice_name1)[0]
+            data -= readfile.read(inps.file, datasetName=slice_name2)[0]
+            print('converting range to phase')
+            data *= range2phase
+            if inps.ref_yx:
+                data -= data[inps.ref_yx[0], inps.ref_yx[1]]
+        else:
+            slice_name = view.check_dataset_input(slice_list, inps.dset)[0][0]
+            data = readfile.read(inps.file, datasetName=slice_name)[0]
+
+        # metadata
+        atr['DATE'] = date1[2:8]
+        atr['DATE12'] = '{}-{}'.format(date1[2:8], date2[2:8])
+        if dname == 'displacement':
             atr['FILE_TYPE'] = '.unw'
             atr['UNIT'] = 'radian'
-        elif dsetFamily == 'coherence':
+        elif 'coherence' in dname.lower():
             atr['FILE_TYPE'] = '.cor'
             atr['UNIT'] = '1'
-        elif dsetFamily == 'wrapPhase':
+        elif dname == 'height':
+            atr['FILE_TYPE'] = '.dem'
+            atr['DATA_TYPE'] = 'int16'
+        else:
+            raise ValueError('unrecognized input dataset type: {}'.format(inps.dset))
+
+        # output filename
+        if not inps.outfile:
+            inps.outfile = '{}{}'.format(date12, atr['FILE_TYPE'])
+
+    elif k == 'ifgramStack':
+        dname, date12 = inps.dset.split('-')
+        date1, date2 = date12.split('_')
+
+        # read / prepare data
+        data = readfile.read(inps.file, datasetName=inps.dset)[0]
+        if dname.startswith('unwrapPhase'):
+            if 'REF_X' in atr.keys():
+                data -= data[int(atr['REF_Y']), int(atr['REF_X'])]
+                print('consider reference pixel in y/x: ({}, {})'.format(atr['REF_Y'], atr['REF_X']))
+            else:
+                print('No REF_Y/X found.')
+
+        # metadata
+        atr['DATE'] = date1[2:8]
+        atr['DATE12'] = '{}-{}'.format(date1[2:8], date2[2:8])
+        if dname.startswith('unwrapPhase'):
+            atr['FILE_TYPE'] = '.unw'
+            atr['UNIT'] = 'radian'
+        elif dname == 'coherence':
+            atr['FILE_TYPE'] = '.cor'
+            atr['UNIT'] = '1'
+        elif dname == 'wrapPhase':
             atr['FILE_TYPE'] = '.int'
             atr['UNIT'] = 'radian'
         else:
-            raise Exception('unrecognized dataset type: {}'.format(inps.dset))
+            raise ValueError('unrecognized dataset type: {}'.format(inps.dset))
 
+        # output filename
         if not inps.outfile:
-            inps.outfile = '{}{}'.format(atr['DATE12'], atr['FILE_TYPE'])
+            inps.outfile = '{}{}'.format(date12, atr['FILE_TYPE'])
             if inps.file.startswith('geo_'):
                 inps.outfile = 'geo_'+inps.outfile
 
     else:
+        # temporal coherence
         if 'coherence' in k.lower():
             atr['FILE_TYPE'] = '.cor'
+
         elif k in ['mask']:
             atr['FILE_TYPE'] = '.msk'
             atr['DATA_TYPE'] = 'byte'
+
         elif k in ['geometry'] and inps.dset == 'height':
             if 'Y_FIRST' in atr.keys():
                 atr['FILE_TYPE'] = '.dem'
@@ -183,7 +276,6 @@ def main(iargs=None):
 
     atr = clean_metadata4roipac(atr)
 
-    #print('writing >>> {}'.format(out_file))
     writefile.write(data, out_file=out_file, metadata=atr)
     return inps.outfile
 

--- a/pysar/utils/readfile.py
+++ b/pysar/utils/readfile.py
@@ -1,6 +1,6 @@
 ############################################################
 # Program is part of PySAR                                 #
-# Copyright(c) 2013-2018, Zhang Yunjun, Heresh Fattahi     #
+# Copyright(c) 2013-2019, Zhang Yunjun, Heresh Fattahi     #
 # Author:  Zhang Yunjun, Heresh Fattahi, 2013              #
 ############################################################
 # Recommend import:
@@ -16,16 +16,19 @@ import h5py
 import json
 import numpy as np
 
-from pysar.objects import (datasetUnitDict,
-                           geometry,
-                           geometryDatasetNames,
-                           giantIfgramStack,
-                           giantTimeseries,
-                           ifgramDatasetNames,
-                           ifgramStack,
-                           timeseriesDatasetNames,
-                           timeseries,
-                           HDFEOS)
+from pysar.objects import (
+    datasetUnitDict,
+    geometry,
+    geometryDatasetNames,
+    giantIfgramStack,
+    giantTimeseries,
+    ifgramDatasetNames,
+    ifgramStack,
+    timeseriesDatasetNames,
+    timeseries,
+    HDFEOS
+)
+
 
 standardMetadataKeys = {
     # ordered in alphabet by value names
@@ -97,17 +100,6 @@ ENVI_BAND_INTERLEAVE = {
     'LINE': 'BIL',
     'PIXEL': 'BIP',
 }
-
-
-###########################################################################
-# obsolete variables
-multi_group_hdf5_file = ['interferograms',
-                         'coherence',
-                         'wrapped',
-                         'snaphu_connect_component']
-multi_dataset_hdf5_file = ['timeseries', 'geometry']
-single_dataset_hdf5_file = ['dem', 'mask', 'temporal_coherence', 'velocity']
-
 
 ###########################################################################
 ## Slice-based data identification for data reading:
@@ -548,6 +540,7 @@ def read_attribute(fname, datasetName=None, standardize=True, metafile_ext=None)
         d1_list = [i for i in f.keys() if isinstance(f[i], h5py.Dataset) and f[i].ndim >= 2]
 
         # FILE_TYPE - k
+        py2_pysar_stack_files = ['interferograms', 'coherence', 'wrapped'] #obsolete pysar format
         if any(i in d1_list for i in ['unwrapPhase']):
             k = 'ifgramStack'
         elif any(i in d1_list for i in ['height', 'latitude', 'azimuthCoord']):
@@ -560,8 +553,8 @@ def read_attribute(fname, datasetName=None, standardize=True, metafile_ext=None)
             k = 'giantTimeseries'
         elif any(i in d1_list for i in ['igram', 'figram']):
             k = 'giantIfgramStack'
-        elif any(i in g1_list for i in multi_group_hdf5_file):      # old pysar format
-            k = list(set(g1_list) & set(multi_group_hdf5_file))[0]
+        elif any(i in g1_list for i in py2_pysar_stack_files):
+            k = list(set(g1_list) & set(py2_pysar_stack_files))[0]
         elif len(d1_list) > 0:
             k = d1_list[0]
         elif len(g1_list) > 0:


### PR DESCRIPTION
+ objects/pysarobj: add HDFEOS.get_date_list()

+ utils/readfile: remove the following obsolete global variables for py2 psyar:
   - multi_group_hdf5_file
   - multi_dataset_hdf5_file
   - single_dataset_hdf5_file

+ save_roipac:
   - remove --ref-date option because it's not convenient to use
   - support date1_date2 input for timeseries and HDFEOS files to change reference date easily.
   - support HDF-EOS5 file, including the displacement, temporalCoherence and all geometry datasets.