### PR TITLE
pysarApp: expose more parameters for empirical tropospheric delay correction

### DIFF
--- a/pysar/defaults/pysarApp.cfg
+++ b/pysar/defaults/pysarApp.cfg
@@ -55,12 +55,12 @@ pysar.networkInversion.numWorker        = 40
 
 
 ########## Tropospheric Delay Correction
-pysar.troposphericDelay.method          = pyaps
-pysar.troposphericDelay.weatherModel    = ECMWF
-pysar.troposphericDelay.weatherDir      = ${WEATHER_DIR}
-pysar.troposphericDelay.polyOrder       = 1
-pysar.troposphericDelay.looks           = 8
-
+pysar.troposphericDelay.method             = pyaps
+pysar.troposphericDelay.weatherModel       = ECMWF
+pysar.troposphericDelay.weatherDir         = ${WEATHER_DIR}
+pysar.troposphericDelay.polyOrder          = 1
+pysar.troposphericDelay.looks              = 8
+pysar.troposphericDelay.empiricalThreshold = 0
 
 ########## Phase Ramp Removal
 pysar.deramp            = no

--- a/pysar/defaults/pysarApp.cfg
+++ b/pysar/defaults/pysarApp.cfg
@@ -55,12 +55,12 @@ pysar.networkInversion.numWorker        = 40
 
 
 ########## Tropospheric Delay Correction
-pysar.troposphericDelay.method             = pyaps
-pysar.troposphericDelay.weatherModel       = ECMWF
-pysar.troposphericDelay.weatherDir         = ${WEATHER_DIR}
-pysar.troposphericDelay.polyOrder          = 1
-pysar.troposphericDelay.looks              = 8
-pysar.troposphericDelay.empiricalThreshold = 0
+pysar.troposphericDelay.method          = pyaps
+pysar.troposphericDelay.weatherModel    = ECMWF
+pysar.troposphericDelay.weatherDir      = ${WEATHER_DIR}
+pysar.troposphericDelay.polyOrder       = 1
+pysar.troposphericDelay.looks           = 8
+pysar.troposphericDelay.minCorrelation  = 0
 
 ########## Phase Ramp Removal
 pysar.deramp            = no

--- a/pysar/defaults/pysarApp_template.txt
+++ b/pysar/defaults/pysarApp_template.txt
@@ -119,6 +119,7 @@ pysar.networkInversion.numWorker       = auto #[int > 0], auto for 40, number of
 ## correct tropospheric delay using the following methods:
 ## a. pyaps - use Global Atmospheric Models (GAMs) data (Jolivet et al., 2011, GRL, need to install PyAPS)
 ## b. height_correlation - correct stratified tropospheric delay (Doin et al., 2009, J Applied Geop)
+## -----------------
 ## Notes for pyaps: 
 ## a. GAM data latency: with the most recent SAR data, there will be GAM data missing, the correction
 ## will be applied to dates with GAM data available and skipped for the others.
@@ -126,15 +127,16 @@ pysar.networkInversion.numWorker       = auto #[int > 0], auto for 40, number of
 ## directory, then PySAR applications will download the GAM files into the indicated directory. Also PySAR
 ## application will look for the GAM files in the directory before downloading a new one to prevent downloading
 ## multiple copies if you work with different dataset that cover the same date/time.
+## -----------------
+## Notes for height_correlation:
+## Multilooking is applied to interferograms for estimating the empirical phase/elevation ratio only.
+## Correction is applied to original interferograms if the correction is larger than minCorrelation.
 pysar.troposphericDelay.method         = auto  #[pyaps / height_correlation / no], auto for pyaps
 pysar.troposphericDelay.weatherModel   = auto  #[ERA / MERRA / NARR], auto for ECMWF, for pyaps method
 pysar.troposphericDelay.weatherDir     = auto  #[path2directory], auto for WEATHER_DIR or "./"
 pysar.troposphericDelay.polyOrder      = auto  #[1 / 2 / 3], auto for 1, for height_correlation method
 pysar.troposphericDelay.looks          = auto  #[1-inf], auto for 8, for height_correlation, number of looks
-                                            #applied to interferogram while estimating the empirical ratio.
-pysar.troposphericDelay.minCorrelation = auto  #[0-1], auto for 0, correlation threshold to apply empirical tropospheric
-                                               #correction, if not set, all dates will be corrected.
-
+pysar.troposphericDelay.minCorrelation = auto  #[0.0-1.0], auto for 0, for height_correlation
 
 
 ########## 7. Phase Deramping (optional)

--- a/pysar/defaults/pysarApp_template.txt
+++ b/pysar/defaults/pysarApp_template.txt
@@ -126,13 +126,14 @@ pysar.networkInversion.numWorker       = auto #[int > 0], auto for 40, number of
 ## directory, then PySAR applications will download the GAM files into the indicated directory. Also PySAR
 ## application will look for the GAM files in the directory before downloading a new one to prevent downloading
 ## multiple copies if you work with different dataset that cover the same date/time.
-pysar.troposphericDelay.method       = auto  #[pyaps / height_correlation / no], auto for pyaps
-pysar.troposphericDelay.weatherModel = auto  #[ERA / MERRA / NARR], auto for ECMWF, for pyaps method
-pysar.troposphericDelay.weatherDir   = auto  #[path2directory], auto for WEATHER_DIR or "./"
-pysar.troposphericDelay.polyOrder    = auto  #[1 / 2 / 3], auto for 1, for height_correlation method
-pysar.troposphericDelay.looks        = auto  #[1-inf], auto for 8, for height_correlation, number of looks
-                                             #applied to interferogram while estimating the empirical ratio.
-pysar.troposphericDelay.empiricalThreshold = auto #[0-1], auto for 0, threshold for height-correlation
+pysar.troposphericDelay.method         = auto  #[pyaps / height_correlation / no], auto for pyaps
+pysar.troposphericDelay.weatherModel   = auto  #[ERA / MERRA / NARR], auto for ECMWF, for pyaps method
+pysar.troposphericDelay.weatherDir     = auto  #[path2directory], auto for WEATHER_DIR or "./"
+pysar.troposphericDelay.polyOrder      = auto  #[1 / 2 / 3], auto for 1, for height_correlation method
+pysar.troposphericDelay.looks          = auto  #[1-inf], auto for 8, for height_correlation, number of looks
+                                            #applied to interferogram while estimating the empirical ratio.
+pysar.troposphericDelay.minCorrelation = auto  #[0-1], auto for 0, correlation threshold to apply empirical tropospheric
+                                               #correction, if not set, all dates will be corrected.
 
 
 

--- a/pysar/defaults/pysarApp_template.txt
+++ b/pysar/defaults/pysarApp_template.txt
@@ -132,6 +132,8 @@ pysar.troposphericDelay.weatherDir   = auto  #[path2directory], auto for WEATHER
 pysar.troposphericDelay.polyOrder    = auto  #[1 / 2 / 3], auto for 1, for height_correlation method
 pysar.troposphericDelay.looks        = auto  #[1-inf], auto for 8, for height_correlation, number of looks
                                              #applied to interferogram while estimating the empirical ratio.
+pysar.troposphericDelay.empiricalThreshold = auto #[0-1], auto for 0, threshold for height-correlation
+
 
 
 ########## 7. Phase Deramping (optional)

--- a/pysar/pysarApp.py
+++ b/pysar/pysarApp.py
@@ -681,14 +681,14 @@ class TimeSeriesAnalysis:
             # Phase/Elevation Ratio (Doin et al., 2009)
             if method == 'height_correlation':
                 tropo_look = self.template['pysar.troposphericDelay.looks']
-                tropo_emp_thr = self.template['pysar.troposphericDelay.empiricalThreshold']
+                tropo_min_cor = self.template['pysar.troposphericDelay.minCorrelation']
                 scp_args = '{f} -g {g} -p {p} -m {m} -o {o} -l {l} -t {t}'.format(f=in_file,
                                                                                   g=geom_file,
                                                                                   p=poly_order,
                                                                                   m=mask_file,
                                                                                   o=out_file,
                                                                                   l=tropo_look,
-                                                                                  t=tropo_emp_thr)
+                                                                                  t=tropo_min_cor)
                 print('tropospheric delay correction with height-correlation approach')
                 print('tropo_phase_elevation.py', scp_args)
                 if ut.run_or_skip(out_file=out_file, in_file=in_file) == 'run':

--- a/pysar/pysarApp.py
+++ b/pysar/pysarApp.py
@@ -680,11 +680,15 @@ class TimeSeriesAnalysis:
 
             # Phase/Elevation Ratio (Doin et al., 2009)
             if method == 'height_correlation':
-                scp_args = '{f} -g {g} -p {p} -m {m} -o {o}'.format(f=in_file,
-                                                                    g=geom_file,
-                                                                    p=poly_order,
-                                                                    m=mask_file,
-                                                                    o=out_file)
+                tropo_look = self.template['pysar.troposphericDelay.looks']
+                tropo_emp_thr = self.template['pysar.troposphericDelay.empiricalThreshold']
+                scp_args = '{f} -g {g} -p {p} -m {m} -o {o} -l {l} -t {t}'.format(f=in_file,
+                                                                                  g=geom_file,
+                                                                                  p=poly_order,
+                                                                                  m=mask_file,
+                                                                                  o=out_file,
+                                                                                  l=tropo_look,
+                                                                                  t=tropo_emp_thr)
                 print('tropospheric delay correction with height-correlation approach')
                 print('tropo_phase_elevation.py', scp_args)
                 if ut.run_or_skip(out_file=out_file, in_file=in_file) == 'run':

--- a/pysar/tropo_phase_elevation.py
+++ b/pysar/tropo_phase_elevation.py
@@ -151,6 +151,9 @@ def estimate_phase_elevation_ratio(dem, ts_data, inps):
         dem = multilook_data(dem, inps.num_multilook, inps.num_multilook)
         ts_data = multilook_data(ts_data, inps.num_multilook, inps.num_multilook)
 
+    if inps.threshold > 0.:
+        print('correction_threshold: {}'.format(inps.threshold))
+
     mask_nan = ~np.isnan(dem)
     dem = dem[mask_nan]
     ts_data = ts_data[:, mask_nan]

--- a/pysar/tropo_phase_elevation.py
+++ b/pysar/tropo_phase_elevation.py
@@ -152,7 +152,7 @@ def estimate_phase_elevation_ratio(dem, ts_data, inps):
         ts_data = multilook_data(ts_data, inps.num_multilook, inps.num_multilook)
 
     if inps.threshold > 0.:
-        print('correction_threshold: {}'.format(inps.threshold))
+        print('correlation threshold: {}'.format(inps.threshold))
 
     mask_nan = ~np.isnan(dem)
     dem = dem[mask_nan]


### PR DESCRIPTION
Hi Yunjun,

Issue: The pysarApp_template has the option "pysar.troposphericDelay.looks" for the multi-look in empirical troposphere correction. However, this parameter is not been passed when you call the method.

Will you consider to add the threshold setting option for the empirical troposphere correction since you have already implemented in the method? Or just leave it for the user-defined pipeline?

Regards,
Lei

 